### PR TITLE
feat(mongoose): adding mongooseIndexes decorator

### DIFF
--- a/packages/mongoose/src/decorators/mongooseIndexes.spec.ts
+++ b/packages/mongoose/src/decorators/mongooseIndexes.spec.ts
@@ -1,0 +1,41 @@
+import {expect} from "chai";
+import Sinon from "sinon";
+import {MongooseIndexes} from "./mongooseIndexes";
+import {schemaOptions} from "../utils/schemaOptions";
+
+const sandbox = Sinon.createSandbox();
+describe("@MongooseIndexes()", () => {
+  class Test {}
+
+  it("should store options", () => {
+    // GIVEN
+    const fn = sandbox.stub();
+
+    // WHEN
+    @MongooseIndexes([
+      {fields: {field: "1"}, options: {}},
+      {fields: {field2: "1"}, options: {}}
+    ])
+    class Test {}
+
+    // THEN
+    const options = schemaOptions(Test);
+
+    expect(options).to.deep.eq({
+      indexes: [
+        {
+          fields: {
+            field: "1"
+          },
+          options: {}
+        },
+        {
+          fields: {
+            field2: "1"
+          },
+          options: {}
+        }
+      ]
+    });
+  });
+});

--- a/packages/mongoose/src/decorators/mongooseIndexes.ts
+++ b/packages/mongoose/src/decorators/mongooseIndexes.ts
@@ -1,0 +1,35 @@
+import {schemaOptions} from "../utils/schemaOptions";
+
+/**
+ * Calls schema.index() to define multiple indexes (most likely compound) for the schema.
+ *
+ * ### Example
+ *
+ * ```typescript
+ * @Model()
+ * @MongooseIndexes([{fields: {first: 1, second: 1}, options:{unique: 1}}, {fields: {first: 1, third: 1}, options:{unique: 1}}])
+ * export class EventModel {
+ *
+ *   @Property()
+ *   first: string;
+ *
+ *   @Property()
+ *   second: string;
+ *
+ *   @Property()
+ *   third: string;
+ *
+ * }
+ * ```
+ *
+ * @param indexes - define multiple mongoose indexes
+ * @returns {Function}
+ * @decorator
+ * @mongoose
+ * @class
+ */
+export function MongooseIndexes(indexes: Array<{fields: object; options?: any}>): Function {
+  return (target: any) => {
+    schemaOptions(target, {indexes});
+  };
+}


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature | No

****

## Usage example

Define multiple mongoose schema indexes:

```typescript

  @Model()
  @MongooseIndexes([{fields: {first: 1, second: 1}, options:{unique: 1}}, {fields: {first: 1, third: 1}, options:{unique: 1}}])
  export class EventModel {
 
    @Property()
    first: string;
 
    @Property()
    second: string;
 
    @Property()
    third: string;
 
  }

```


## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
