### PR TITLE
feat(mongoose): Add decorator NumberDecimal to support Decimal128 values

### DIFF
--- a/docs/tutorials/mongoose.md
+++ b/docs/tutorials/mongoose.md
@@ -171,6 +171,18 @@ This works by having a field with the referenced object model's name and a field
 
 <<< @/tutorials/snippets/mongoose/dynamic-references.ts
 
+### Decimal Numbers
+
+`@tsed/mongoose` supports `mongoose` 128-bit decimal floating points data type [Decimal128](https://mongoosejs.com/docs/api.html#mongoose_Mongoose-Decimal128).
+
+The @@NumberDecimal@@ decorator is used to set Decimal128 type for number fields.
+
+<<< @/tutorials/snippets/mongoose/decimal-numbers.ts
+
+Optionally a custom decimal type implementation, such as [big.js](https://www.npmjs.com/package/big.js), can be used by passing a constructor to the field decorator.
+
+<<< @/tutorials/snippets/mongoose/extended-decimal-numbers.ts
+
 ## Register hook
 
 Mongoose allows the developer to add pre and post [hooks / middlewares](http://mongoosejs.com/docs/middleware.html) to the schema. 

--- a/docs/tutorials/snippets/mongoose/decimal-numbers.ts
+++ b/docs/tutorials/snippets/mongoose/decimal-numbers.ts
@@ -1,0 +1,14 @@
+import {Property} from "@tsed/schema";
+import {Model, NumberDecimal, Decimal128} from "@tsed/mongoose";
+
+@Model()
+export class ProductModel {
+  @ObjectID("id")
+  _id: string;
+
+  @Property()
+  sku: string;
+
+  @NumberDecimal()
+  price: Decimal128;
+}

--- a/docs/tutorials/snippets/mongoose/extended-decimal-numbers.ts
+++ b/docs/tutorials/snippets/mongoose/extended-decimal-numbers.ts
@@ -1,0 +1,8 @@
+import {Model, NumberDecimal} from "@tsed/mongoose";
+import Big from "big.js"
+
+@Model()
+export class PriceModel {
+  @NumberDecimal(Big)
+  price: Big;
+}

--- a/packages/mongoose/package.json
+++ b/packages/mongoose/package.json
@@ -23,6 +23,7 @@
     "@tsed/common": "6.50.0",
     "@tsed/core": "6.50.0",
     "@tsed/schema": "6.50.0",
+    "@tsed/ajv": "6.50.0",
     "mongoose": "^5.12.2"
   }
 }

--- a/packages/mongoose/src/decorators/index.ts
+++ b/packages/mongoose/src/decorators/index.ts
@@ -8,6 +8,7 @@ export * from "./lowercase";
 export * from "./model";
 export * from "./mongooseIndex";
 export * from "./mongoosePlugin";
+export * from "./numberDecimal";
 export * from "./objectID";
 export * from "./postHook";
 export * from "./preHook";

--- a/packages/mongoose/src/decorators/numberDecimal.spec.ts
+++ b/packages/mongoose/src/decorators/numberDecimal.spec.ts
@@ -1,0 +1,134 @@
+import {descriptorOf, Store} from "@tsed/core";
+import {deserialize, serialize} from "@tsed/json-mapper/src";
+import {getJsonSchema} from "@tsed/schema";
+import {expect} from "chai";
+import {Types, Schema} from "mongoose";
+import sinon from "sinon";
+import {MONGOOSE_MODEL_NAME, MONGOOSE_SCHEMA} from "../constants";
+import {NumberDecimal, Decimal128} from "./numberDecimal";
+
+describe("@NumberDecimal()", () => {
+  it("should declare a Decimal128 field", () => {
+    // WHEN
+    class Test {
+      @NumberDecimal()
+      price: Decimal128;
+    }
+
+    // THEN
+    const store = Store.from(Test, "price");
+    const schema = getJsonSchema(Test);
+
+    expect(schema).to.deep.eq({
+      properties: {
+        price: {
+          examples: [12.34],
+          type: "number",
+          format: "decimal"
+        }
+      },
+      type: "object"
+    });
+
+    expect(store.get(MONGOOSE_SCHEMA)).to.deep.eq({
+      type: Schema.Types.Decimal128
+    });
+  });
+  it("should deserialize a number value", () => {
+    // WHEN
+    class Model {
+      @NumberDecimal()
+      price: Decimal128;
+    }
+
+    // THEN
+    const result = deserialize(
+      {
+        price: 1234.56
+      },
+      {type: Model, additionalProperties: false}
+    );
+
+    expect(result).to.be.instanceOf(Model);
+    expect(result).to.deep.eq({
+      price: Types.Decimal128.fromString("1234.56")
+    });
+  });
+  it("should serialize a number value", () => {
+    // WHEN
+    class Model {
+      @NumberDecimal()
+      price: Decimal128;
+    }
+
+    const mdl = new Model();
+    mdl.price = Types.Decimal128.fromString("1234.56");
+
+    // THEN
+    const result = serialize(mdl);
+
+    expect(result).to.deep.eq({
+      price: 1234.56
+    });
+  });
+  it("should deserialize a number value using custom constructor", () => {
+    // GIVEN
+    class Decimal {
+      constructor(private value: any) {}
+      toString() {
+        return `${this.value}`;
+      }
+    }
+
+    const fakePrice = new Decimal("1234.56");
+
+    const obj = {Decimal};
+    sinon.stub(obj, "Decimal").returns(fakePrice);
+
+    // WHEN
+    class Model {
+      @NumberDecimal(obj.Decimal)
+      price: Decimal;
+    }
+
+    // THEN
+    const result = deserialize(
+      {
+        price: "1234.56"
+      },
+      {type: Model, additionalProperties: false}
+    );
+
+    expect(obj.Decimal).to.have.been.calledWithExactly("1234.56");
+
+    expect(result).to.be.instanceOf(Model);
+    expect(result).to.deep.eq({
+      price: fakePrice
+    });
+  });
+  it("should serialize a number value using custom constructor", () => {
+    // GIVEN
+    class Decimal {
+      constructor(private value: any) {}
+      toString() {
+        return `${this.value}`;
+      }
+    }
+
+    // WHEN
+    class Model {
+      @NumberDecimal(Decimal)
+      price: Decimal;
+    }
+
+    const mdl = new Model();
+    mdl.price = new Decimal("1234.56");
+
+    // THEN
+    const result = serialize(mdl);
+
+    expect(result).to.deep.eq({
+      price: 1234.56
+    });
+  });
+});

--- a/packages/mongoose/src/decorators/numberDecimal.spec.ts
+++ b/packages/mongoose/src/decorators/numberDecimal.spec.ts
@@ -1,11 +1,11 @@
-import {descriptorOf, Store} from "@tsed/core";
+import {Store} from "@tsed/core";
 import {deserialize, serialize} from "@tsed/json-mapper/src";
 import {getJsonSchema} from "@tsed/schema";
 import {expect} from "chai";
 import {Types, Schema} from "mongoose";
 import sinon from "sinon";
-import {MONGOOSE_MODEL_NAME, MONGOOSE_SCHEMA} from "../constants";
-import {NumberDecimal, Decimal128} from "./numberDecimal";
+import {MONGOOSE_SCHEMA} from "../constants";
+import {NumberDecimal, Decimal128, DecimalFormat} from "./numberDecimal";
 
 describe("@NumberDecimal()", () => {
   it("should declare a Decimal128 field", () => {
@@ -34,6 +34,29 @@ describe("@NumberDecimal()", () => {
       type: Schema.Types.Decimal128
     });
   });
+  it("should declare a decimal number format", () => {
+    // WHEN
+    const format = new DecimalFormat();
+    const validate: (value: any) => boolean = format.validate;
+
+    // THEN
+    const store = Store.from(DecimalFormat);
+
+    expect(store.get("ajv:formats")).to.deep.eq({
+      name: "decimal",
+      options: {
+        type: "number"
+      }
+    });
+
+    expect(validate(undefined)).to.be.false;
+    expect(validate(null)).to.be.false;
+    expect(validate([])).to.be.false;
+    expect(validate({})).to.be.false;
+    expect(validate("0.0")).to.be.true;
+    expect(validate(NaN)).to.be.true;
+    expect(validate(0)).to.be.true;
+  });
   it("should deserialize a number value", () => {
     // WHEN
     class Model {
@@ -45,6 +68,26 @@ describe("@NumberDecimal()", () => {
     const result = deserialize(
       {
         price: 1234.56
+      },
+      {type: Model, additionalProperties: false}
+    );
+
+    expect(result).to.be.instanceOf(Model);
+    expect(result).to.deep.eq({
+      price: Types.Decimal128.fromString("1234.56")
+    });
+  });
+  it("should deserialize a string value", () => {
+    // WHEN
+    class Model {
+      @NumberDecimal()
+      price: Decimal128;
+    }
+
+    // THEN
+    const result = deserialize(
+      {
+        price: "1234.56"
       },
       {type: Model, additionalProperties: false}
     );
@@ -71,7 +114,21 @@ describe("@NumberDecimal()", () => {
       price: 1234.56
     });
   });
-  it("should deserialize a number value using custom constructor", () => {
+  it("should serialize an undefined value", () => {
+    // WHEN
+    class Model {
+      @NumberDecimal()
+      price?: Decimal128;
+    }
+
+    const mdl = new Model();
+
+    // THEN
+    const result = serialize(mdl);
+
+    expect(result).to.not.have.property("price");
+  });
+  it("should deserialize a number value using custom decimal", () => {
     // GIVEN
     class Decimal {
       constructor(private value: any) {}
@@ -106,7 +163,7 @@ describe("@NumberDecimal()", () => {
       price: fakePrice
     });
   });
-  it("should serialize a number value using custom constructor", () => {
+  it("should serialize a number value using custom decimal", () => {
     // GIVEN
     class Decimal {
       constructor(private value: any) {}
@@ -130,5 +187,68 @@ describe("@NumberDecimal()", () => {
     expect(result).to.deep.eq({
       price: 1234.56
     });
+  });
+  it("should convert Decimal128 to custom implementation", () => {
+    // GIVEN
+    class Decimal {
+      constructor(private value: any) {}
+      toString() {
+        return `${this.value}`;
+      }
+    }
+
+    const testDecimal = Types.Decimal128.fromString("1234.56");
+    const fakePrice = new Decimal("1234.56");
+
+    const obj = {Decimal};
+    sinon.stub(obj, "Decimal").returns(fakePrice);
+
+    // WHEN
+    class Model {
+      @NumberDecimal(obj.Decimal)
+      price: Decimal;
+    }
+
+    const mdl = new Model();
+    mdl.price = new Decimal("1234.56");
+
+    // THEN
+    const store = Store.from(Model, "price");
+    const schema = store.get(MONGOOSE_SCHEMA);
+
+    expect(schema.get).to.be.a("function");
+    expect(schema.get(testDecimal)).to.be.eq(fakePrice);
+    expect(obj.Decimal).to.have.been.calledWithExactly(testDecimal);
+  });
+  it("should not convert custom decimal again", () => {
+    // GIVEN
+    class Decimal {
+      constructor(private value: any) {}
+      toString() {
+        return `${this.value}`;
+      }
+    }
+
+    const fakePrice = new Decimal("1234.56");
+
+    const obj = {Decimal};
+    sinon.stub(obj, "Decimal").returns(fakePrice);
+
+    // WHEN
+    class Model {
+      @NumberDecimal(obj.Decimal)
+      price: Decimal;
+    }
+
+    const mdl = new Model();
+    mdl.price = new Decimal("1234.56");
+
+    // THEN
+    const store = Store.from(Model, "price");
+    const schema = store.get(MONGOOSE_SCHEMA);
+
+    expect(schema.get).to.be.a("function");
+    expect(schema.get(fakePrice)).to.be.eq(fakePrice);
+    expect(obj.Decimal).to.have.not.been.called;
   });
 });

--- a/packages/mongoose/src/decorators/numberDecimal.ts
+++ b/packages/mongoose/src/decorators/numberDecimal.ts
@@ -1,0 +1,62 @@
+import {isString, StoreMerge, useDecorators} from "@tsed/core";
+import {OnDeserialize, OnSerialize, serialize} from "@tsed/json-mapper";
+import {Description, Example, Name, Format, JsonEntityFn, string, number, Property} from "@tsed/schema";
+import {Types, Schema as MongooseSchema} from "mongoose";
+import {MONGOOSE_SCHEMA} from "../constants";
+
+import {MongooseSchemaTypes} from "../interfaces/MongooseSchemaTypes";
+import {MongooseModels} from "../registries/MongooseModels";
+
+function isDecimal(value: undefined | number | any) {
+  return value && value._bsontype === "Decimal128";
+}
+
+/**
+ * Tell Mongoose whether to define an Decimal128 property.
+ * Will be serialized as `number` with format as `decimal`.
+ * ### Example
+ *
+ * ```typescript
+ * @Model()
+ * export class PriceModel {
+ *   @NumberDecimal()
+ *   price: Decimal128;
+ * }
+ * ```
+ * Optionally using custom decimal type, such as `Big` from big.js
+ * ```typescript
+ * @Model()
+ * export class PriceModel {
+ *   @NumberDecimal(Big)
+ *   price: Big;
+ * }
+ * ```
+ * @param type Optional decimal type constructor
+ * @decorator
+ * @mongoose
+ * @schema
+ */
+export function NumberDecimal(type?: any) {
+  return useDecorators(
+    Property(Number),
+    Format("decimal"),
+    Example(12.34),
+    StoreMerge(MONGOOSE_SCHEMA, {
+      type: MongooseSchema.Types.Decimal128
+    }),
+    OnDeserialize((value) => {
+      if (type) {
+        return new type(value);
+      }
+      if (isString(value)) {
+        return Types.Decimal128.fromString(value);
+      }
+      return Types.Decimal128.fromString(`${value}`);
+    }),
+    OnSerialize((value: any, ctx) => {
+      return Number(value);
+    })
+  );
+}
+
+export type Decimal128 = Types.Decimal128;


### PR DESCRIPTION
I've implemented a ``NumberDecimal`` decorator which can be used to set mongoose's Decimal128 type for number fields.
Looking forward to your feedback!

## Information

Type | Breaking change
---|---
Feature | No

****

## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {Property} from "@tsed/schema";
import {Model, NumberDecimal, Decimal128} from "@tsed/mongoose";

@Model()
export class ProductModel {
  @ObjectID("id")
  _id: string;

  @Property()
  sku: string;

  @NumberDecimal()
  price: Decimal128;
}
```

or alternatively using custom implementation, e.g. big.js:

```typescript
import Big from "big.js"

@Model()
export class PriceModel {
  @NumberDecimal(Big)
  price: Big;
}
```

## Todos

- [x] Tests
- [x] Coverage
- [x] Example
- [x] Documentation
