### PR TITLE
docs: Fix path issue on documentation

### DIFF
--- a/docs/tutorials/mongoose.md
+++ b/docs/tutorials/mongoose.md
@@ -158,7 +158,7 @@ In this example a **Customer** has many **Contracts** and each **Contract** has 
 () => ModelName
 ```
 
-<<< @/docs/tutorials/snippets/mongoose/extended-circular-reference.ts
+<<< @/tutorials/snippets/mongoose/extended-circular-reference.ts
 
 ### Virtual References
 

--- a/docs/tutorials/socket-io.md
+++ b/docs/tutorials/socket-io.md
@@ -158,7 +158,7 @@ And this in your service
 
 In plain javascript you could connect like this.
 
-<<< @/docs/tutorials/snippets/socketio/basicClientSetup.html
+<<< @/tutorials/snippets/socketio/basicClientSetup.html
 
 
 


### PR DESCRIPTION
## Information

Type | Breaking change
---|---
Feature/Fix/Doc/Chore | Yes/No

****

<!--
## Usage example

Example to use your feature and to improve the documentation after merging your PR:
```typescript
import {} from "@tsed/common";

```
-->

## Todos

- [ ] Tests
- [ ] Coverage
- [ ] Example
- [ ] Documentation
