### PR TITLE
fix(platform-http): allow passing settings without root module in options()

### DIFF
--- a/packages/platform/platform-http/src/common/builder/PlatformBuilder.spec.ts
+++ b/packages/platform/platform-http/src/common/builder/PlatformBuilder.spec.ts
@@ -166,6 +166,30 @@ describe("PlatformBuilder", () => {
         expect(configuration().get("httpsPort")).toEqual(false);
       });
     });
+    describe("static options()", () => {
+      it("should preserve a root module without settings", () => {
+        expect(PlatformBuilder.options(FakeAdapter, ServerModule)).toEqual({
+          rootModule: ServerModule,
+          adapter: FakeAdapter
+        });
+      });
+
+      it("should preserve the root module and settings", () => {
+        expect(PlatformBuilder.options(FakeAdapter, ServerModule, {httpPort: 8080})).toEqual({
+          rootModule: ServerModule,
+          httpPort: 8080,
+          adapter: FakeAdapter
+        });
+      });
+
+      it("should accept settings without a root module", () => {
+        expect(PlatformBuilder.options(FakeAdapter, {httpPort: 8080})).toEqual({
+          rootModule: undefined,
+          httpPort: 8080,
+          adapter: FakeAdapter
+        });
+      });
+    });
     describe("bootstrap()", () => {
       it("should bootstrap platform", async () => {
         // WHEN

--- a/packages/platform/platform-http/src/common/builder/PlatformBuilder.ts
+++ b/packages/platform/platform-http/src/common/builder/PlatformBuilder.ts
@@ -24,7 +24,7 @@ import {PlatformLayer} from "@tsed/platform-router";
 import {PlatformRouteDetails} from "../domain/PlatformRouteDetails.js";
 import type {PlatformStaticsSettings} from "../config/PlatformStaticsSettings.js";
 import {Route} from "../interfaces/Route.js";
-import {isClass, type Type} from "@tsed/core";
+import {type Type} from "@tsed/core";
 import {application} from "../fn/application.js";
 import {closeServer} from "../utils/closeServer.js";
 import {createInjector} from "../utils/createInjector.js";
@@ -115,12 +115,17 @@ export class PlatformBuilder<App = TsED.Application> {
 
   static options<Adapter>(
     adapter: Type<PlatformAdapter<Adapter>>,
-    module: Type<any> | Partial<TsED.Configuration>,
+    rootModule: Type<any> | Partial<TsED.Configuration>,
     settings?: Partial<TsED.Configuration>
   ) {
+    if (typeof rootModule !== "function") {
+      settings = rootModule;
+      rootModule = undefined!;
+    }
+
     return {
-      rootModule: settings ? (module as Type) : undefined,
-      ...(!isClass(module) && !settings ? (module as Partial<TsED.Configuration>) : settings),
+      rootModule,
+      ...settings,
       adapter
     };
   }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved platform configuration handling when initializing with settings only.
  - Preserved provided settings while correctly defaulting the root module when omitted.
  - Continued to include the configured adapter in generated platform options.

- **Tests**
  - Added coverage for root-module-only, root module with settings, and settings-only configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->