### PR TITLE
docs: fix @Mininum decorator name and other typos in documentation

### DIFF
--- a/docs/docs/authentication.md
+++ b/docs/docs/authentication.md
@@ -17,7 +17,7 @@ we have to use the @@UseAuth@@ decorator.
 <<< @/docs/snippets/authentication/auth-example.ts
 
 ::: tip
-If you planed to use `Passport.js`, it's recommended to follow the [Passport.js guide here](/tutorials/passport.md).
+If you planned to use `Passport.js`, it's recommended to follow the [Passport.js guide here](/tutorials/passport.md).
 :::
 
 Any middleware can be used as an authentication strategy. Just keep in mind, to work properly, the middleware must use @@Context@@

--- a/docs/docs/cache.md
+++ b/docs/docs/cache.md
@@ -56,7 +56,7 @@ import {Configuration} from "@tsed/di";
     ttl: 300, // default TTL
     store: "memory",
     prefix: "myPrefix" // to namespace all keys related to the cache
-    // options options depending on the choosen storage type
+    // options options depending on the chosen storage type
   }
 })
 export class Server {}
@@ -381,7 +381,7 @@ export class MyController {
 
 ## Define when a value can be cached <Badge text="7.6.0+" />
 
-Sometimes, you don't want to store in cache a value because isn't consistant to have it.
+Sometimes, you don't want to store in cache a value because isn't consistent to have it.
 For example, you can avoid caching data when the result is nullish:
 
 ```typescript
@@ -534,7 +534,7 @@ import {Configuration} from "@tsed/di";
   cache: {
     ttl: 300, // default TTL
     caches: [memoryCache, someOtherCache]
-    // options options depending on the choosen storage type
+    // options options depending on the chosen storage type
   }
 })
 export class Server {}

--- a/docs/docs/cache.md
+++ b/docs/docs/cache.md
@@ -56,7 +56,7 @@ import {Configuration} from "@tsed/di";
     ttl: 300, // default TTL
     store: "memory",
     prefix: "myPrefix" // to namespace all keys related to the cache
-    // options options depending on the chosen storage type
+    // options depending on the chosen storage type
   }
 })
 export class Server {}
@@ -381,7 +381,7 @@ export class MyController {
 
 ## Define when a value can be cached <Badge text="7.6.0+" />
 
-Sometimes, you don't want to store in cache a value because isn't consistent to have it.
+Sometimes, you don't want to store in cache a value because it isn't consistent to store it.
 For example, you can avoid caching data when the result is nullish:
 
 ```typescript
@@ -534,7 +534,7 @@ import {Configuration} from "@tsed/di";
   cache: {
     ttl: 300, // default TTL
     caches: [memoryCache, someOtherCache]
-    // options options depending on the chosen storage type
+    // options depending on the chosen storage type
   }
 })
 export class Server {}

--- a/docs/docs/configuration/server-options.md
+++ b/docs/docs/configuration/server-options.md
@@ -301,7 +301,7 @@ security issue.
 
 Pass the plain object to the model constructor. By default, `true`.
 
-It may be a potential security issue if you have as constructor with this following code:
+It may be a potential security issue if you have a constructor with the following code:
 
 ```typescript
 class MyModel {

--- a/docs/docs/configuration/server-options.md
+++ b/docs/docs/configuration/server-options.md
@@ -301,7 +301,7 @@ security issue.
 
 Pass the plain object to the model constructor. By default, `true`.
 
-It may be a potential security issue if you have as constructor with this followings code:
+It may be a potential security issue if you have as constructor with this following code:
 
 ```typescript
 class MyModel {

--- a/docs/docs/json-mapper.md
+++ b/docs/docs/json-mapper.md
@@ -43,7 +43,7 @@ Enable this option is dangerous and may be a potential security issue.
 
 Pass the plain object to the model constructor. By default, `true`.
 
-It may be a potential security issue if you have as constructor with this following code:
+It may be a potential security issue if you have a constructor with the following code:
 
 ```typescript
 class MyModel {

--- a/docs/docs/json-mapper.md
+++ b/docs/docs/json-mapper.md
@@ -43,7 +43,7 @@ Enable this option is dangerous and may be a potential security issue.
 
 Pass the plain object to the model constructor. By default, `true`.
 
-It may be a potential security issue if you have as constructor with this followings code:
+It may be a potential security issue if you have as constructor with this following code:
 
 ```typescript
 class MyModel {

--- a/docs/docs/logger.md
+++ b/docs/docs/logger.md
@@ -40,7 +40,7 @@ bun add @tsed/logger
 Ts.ED logger supports many features, and is optimized to be used in production:
 
 - @@ContextLogger@@, in **production** mode, caches all request logs until the response is sent to your consumer.
-  See [request logger](/docs/logger.html#request-logger) section bellow.
+  See [request logger](/docs/logger.html#request-logger) section below.
 - [Layouts](https://logger.tsed.dev/layouts) support,
 - [Appenders](https://logger.tsed.dev/appenders) support;
 
@@ -109,7 +109,7 @@ The following appenders are available:
 ::: tip
 You can create your own layout/appender:
 
-- [Customize appender (chanel)](https://logger.tsed.dev/appenders/custom.html),
+- [Customize appender (channel)](https://logger.tsed.dev/appenders/custom.html),
 - [Customize layout](https://logger.tsed.dev/layouts/custom.html)
 
 :::
@@ -158,7 +158,7 @@ This configuration will display the log as following:
 {"startTime":"2017-06-05T22:23:08.479Z","categoryName":"json-test","data":["this is just a test"],"level":"INFO","context":{}}
 ```
 
-It's more useful if you planed to parse the log with LogStash or any log tool parser.
+It's more useful if you planned to parse the log with LogStash or any log tool parser.
 
 ## Inject logger
 

--- a/docs/docs/middlewares.md
+++ b/docs/docs/middlewares.md
@@ -63,7 +63,7 @@ export class Server {}
 The middlewares added through `middlewares` options will always be registered after the middlewares registered through
 the hook methods!
 
-::: warn
+::: warning
 Only Express/Koa middlewares can be added on `$beforeInit`, `$onInit` and `$afterInit` hooks.
 
 During `$beforeInit`, `$onInit` and `$afterInit` steps the PlatformContext is not available. Injectable Ts.ED middleware
@@ -146,7 +146,7 @@ called when an error occurs on th decorated endpoint.
 
 :::
 
-If you planed to catch errors globally see our [Exception filter](/docs/exceptions) page.
+If you planned to catch errors globally see our [Exception filter](/docs/exceptions) page.
 
 ## Specifics parameters decorators
 

--- a/docs/docs/model.md
+++ b/docs/docs/model.md
@@ -1935,7 +1935,7 @@ This feature is only available for OpenAPI 3.
 
 ## Annotations
 
-JSON Schema includes a few keywords and Ts.ED provide also these corresponding decorators like @@Title@@,
+JSON Schema includes a few keywords and Ts.ED also provides corresponding decorators, such as @@Title@@,
 @@Description@@, @@Default@@, @@Example@@ that aren’t strictly used for validation, but are used to describe parts of a
 schema.
 

--- a/docs/docs/model.md
+++ b/docs/docs/model.md
@@ -1935,7 +1935,7 @@ This feature is only available for OpenAPI 3.
 
 ## Annotations
 
-JSON Schema includes a few keywords and Ts.ED provide also theses corresponding decorators like @@Title@@,
+JSON Schema includes a few keywords and Ts.ED provide also these corresponding decorators like @@Title@@,
 @@Description@@, @@Default@@, @@Example@@ that aren’t strictly used for validation, but are used to describe parts of a
 schema.
 

--- a/docs/docs/pipes.md
+++ b/docs/docs/pipes.md
@@ -21,7 +21,7 @@ Pipes have two typical use cases:
   the data is incorrect
 
 Pipes are called when an Incoming request is handled by the controller route handler and operate on **the method's
-parameters**. It takes **Request** or **Response** object and transform theses object to the expected value.
+parameters**. It takes **Request** or **Response** object and transform these object to the expected value.
 
 Pipe receives the argument where it is placed. This means that each parameter can invoke a list of pipes, which can be
 different for each parameter.

--- a/docs/docs/pipes.md
+++ b/docs/docs/pipes.md
@@ -21,7 +21,7 @@ Pipes have two typical use cases:
   the data is incorrect
 
 Pipes are called when an Incoming request is handled by the controller route handler and operate on **the method's
-parameters**. It takes **Request** or **Response** object and transform these object to the expected value.
+parameters**. It takes a **Request** or **Response** object and transforms it into the expected value.
 
 Pipe receives the argument where it is placed. This means that each parameter can invoke a list of pipes, which can be
 different for each parameter.

--- a/docs/docs/providers.md
+++ b/docs/docs/providers.md
@@ -369,7 +369,7 @@ to `ProviderScope.INSTANCE`.
 This feature simplifies dependency management when working with multiple implementations of the same interface using
 type code.
 
-Using a token, you can configure injectable classe to be resolved as an array of instances using `type` option:
+Using a token, you can configure injectable class to be resolved as an array of instances using `type` option:
 
 ::: code-group
 <<< @/docs/snippets/providers/decorators/inject-many-declaration.ts [Decorators]

--- a/docs/docs/providers.md
+++ b/docs/docs/providers.md
@@ -369,7 +369,7 @@ to `ProviderScope.INSTANCE`.
 This feature simplifies dependency management when working with multiple implementations of the same interface using
 type code.
 
-Using a token, you can configure injectable class to be resolved as an array of instances using `type` option:
+Using a token, you can configure an injectable class to be resolved as an array of instances using the `type` option:
 
 ::: code-group
 <<< @/docs/snippets/providers/decorators/inject-many-declaration.ts [Decorators]

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -542,7 +542,7 @@ your server must be executed for integration test.
 ## Pros / Cons
 
 ::: warning
-Use `PlatformTest.boostrap()` is not recommended in Jest environment.  
+Use `PlatformTest.bootstrap()` is not recommended in Jest environment.  
 This method is practical for carrying out some integration tests but consumes a lot of resources which can lead to a
 significant slowdown in your tests or even cause timeouts.
 

--- a/docs/docs/testing.md
+++ b/docs/docs/testing.md
@@ -542,7 +542,7 @@ your server must be executed for integration test.
 ## Pros / Cons
 
 ::: warning
-Use `PlatformTest.bootstrap()` is not recommended in Jest environment.  
+Using `PlatformTest.bootstrap()` is not recommended in a Jest environment.  
 This method is practical for carrying out some integration tests but consumes a lot of resources which can lead to a
 significant slowdown in your tests or even cause timeouts.
 

--- a/docs/introduction/migrate-from-v6.md
+++ b/docs/introduction/migrate-from-v6.md
@@ -69,7 +69,7 @@ export class CalendarCtrl {
     // GET raw router (Express.Router or Koa.Router)
     console.log(router.callback()); // v7 removed
     console.log(router.getRouter()); // removed
-    console.log(router.raw); // return PlatformRouter itself intead Express.Router
+    console.log(router.raw); // return PlatformRouter itself instead Express.Router
   }
 
   myMethod(req: any, res: any, next: any) {}
@@ -453,4 +453,4 @@ The following Ts.ED packages are removed:
 
 ### @tsed/terminus
 
-- Remove BeforeShutdown, OnSignal, OnShutdown, OnSendFailureDuringShutdown decorators. Use followings instead `$beforeShutdown`, `$onSignal`, `$onSignal`, `$onShutdown` or `$onSendFailureDuringShutdown`.
+- Remove BeforeShutdown, OnSignal, OnShutdown, OnSendFailureDuringShutdown decorators. Use the following instead `$beforeShutdown`, `$onSignal`, `$onSignal`, `$onShutdown` or `$onSendFailureDuringShutdown`.

--- a/docs/introduction/migrate-from-v7.md
+++ b/docs/introduction/migrate-from-v7.md
@@ -294,7 +294,7 @@ fs.readFile();
 ```
 
 ::: warning
-This import notation works only if have `"esModuleInterop": true` in your tsconfig.json. Otherwhise, use:
+This import notation works only if have `"esModuleInterop": true` in your tsconfig.json. Otherwise, use:
 
 ```ts
 import * as fs from "fs-extra";
@@ -632,4 +632,4 @@ bun add @tsed/platform-http
 
 :::
 
-That alls! You code base is now optimized for v8.
+That's all! Your code base is now optimized for v8.

--- a/docs/plugins/create-your-own-plugins.md
+++ b/docs/plugins/create-your-own-plugins.md
@@ -113,8 +113,8 @@ Ts.ED marketplace scans regularly the NPM registry to find new plugins.
 To appear on the Ts.ED marketplace, you have to publish your plugin on the NPM registry
 with one of the following name patterns:
 
-- `tsed-plugin-*` in the name of your scope and package (recommanded)
+- `tsed-plugin-*` in the name of your scope and package (recommended)
 - `tsed-*` or`@tsed*/` in the name of your package,
 - or adding `Ts.ED` in your description package.json field.
 
-Thats it! Your plugin will be automatically listed on the Ts.ED marketplace.
+That's it! Your plugin will be automatically listed on the Ts.ED marketplace.

--- a/docs/tutorials/ajv.md
+++ b/docs/tutorials/ajv.md
@@ -279,7 +279,7 @@ describe("Product", () => {
 ```
 
 ::: warning
-If you planed to create keyword that transform the data, you have to set `returnsCoercedValues` to `true` in your
+If you planned to create keyword that transform the data, you have to set `returnsCoercedValues` to `true` in your
 configuration.
 :::
 

--- a/docs/tutorials/bullmq.md
+++ b/docs/tutorials/bullmq.md
@@ -280,7 +280,7 @@ class MyService {
     // When passing only a name, the job will be dispatched in a queue named "default"
     await this.dispatcher.dispatch("some-name", {msg: "this message is part of the payload for the job"});
 
-    // You can also specifiy which queue to use
+    // You can also specify which queue to use
     await this.dispatcher.dispatch({queue: "some-queue", name: "some-name"}, {msg: "this message is part of the payload for the job"});
   }
 }

--- a/docs/tutorials/mikroorm.md
+++ b/docs/tutorials/mikroorm.md
@@ -205,7 +205,7 @@ export class User {
   lastName!: string;
 
   @Property()
-  @Mininum(0)
+  @Minimum(0)
   @Maximum(100)
   age!: number;
 }

--- a/docs/tutorials/mikroorm.md
+++ b/docs/tutorials/mikroorm.md
@@ -185,7 +185,7 @@ export class UsersService {
 To begin, we need to define an Entity MikroORM like this and use Ts.ED Decorator to define the JSON Schema.
 
 ```typescript
-import {MaxLength, Required} from "@tsed/schema";
+import {Maximum, MaxLength, Minimum, Required} from "@tsed/schema";
 import {Entity, Property, PrimaryKey, Property} from "@mikro-orm/core";
 
 @Entity()

--- a/docs/tutorials/objection.md
+++ b/docs/tutorials/objection.md
@@ -18,7 +18,7 @@ This tutorial show yous how you can use [Objection.js](https://vincit.github.io/
 ## Installation
 
 Before using the `@tsed/objection` package, we need to install
-the [Obection.js](https://www.npmjs.com/package/objection) and [Knex](https://www.npmjs.com/package/knex) modules.
+the [Objection.js](https://www.npmjs.com/package/objection) and [Knex](https://www.npmjs.com/package/knex) modules.
 
 Install the dependencies:
 

--- a/docs/tutorials/oidc.md
+++ b/docs/tutorials/oidc.md
@@ -205,7 +205,7 @@ export type REDIS_CONNECTION = Redis;
 
 registerConnectionProvider({
   provide: REDIS_CONNECTION,
-  name: "default" // you can change this name at your conveniance
+  name: "default" // you can change this name at your convenience
 });
 ```
 
@@ -331,7 +331,7 @@ In your controller's directory, create the `oidc/InteractionsCtrl.ts` file and c
 
 ::: tip Note
 The controller Interactions exposes the routes to display any interaction. Here we expose the route
-GET `/interation/:uid`
+GET `/interaction/:uid`
 
 The `uid` is the unique session id used by oidc-provider to identify the current user flow.
 :::
@@ -467,7 +467,7 @@ import {LoginInteraction} from "../../interactions/LoginInteraction";
 @Interactions({
   path: "/interaction/:uid",
   children: [
-    LoginInteraction // register its children interations
+    LoginInteraction // register its children interactions
   ]
 })
 export class InteractionsCtrl {

--- a/docs/tutorials/serverless.md
+++ b/docs/tutorials/serverless.md
@@ -1,9 +1,9 @@
 ---
-description: "Guide to deploy your Ts.ED application on Serveless."
+description: "Guide to deploy your Ts.ED application on Serverless."
 head:
   - - meta
     - name: description
-      content: Guide to deploy your Ts.ED application on Serveless.
+      content: Guide to deploy your Ts.ED application on Serverless.
   - - meta
     - name: keywords
       content: ts.ed express typescript aws node.js javascript decorators

--- a/docs/tutorials/stripe.md
+++ b/docs/tutorials/stripe.md
@@ -269,7 +269,7 @@ describe("Stripe", () => {
 
 ### Known issue
 
-If you have the followings message, it means you have an issue with your STRIPE_WEBHOOK_SECRET.
+If you have the following message, it means you have an issue with your STRIPE_WEBHOOK_SECRET.
 
 ```sh
 Error message: No signatures found matching the expected signature for payload. Are you passing the raw request body you received from Stripe?

--- a/docs/tutorials/typeorm.md
+++ b/docs/tutorials/typeorm.md
@@ -26,7 +26,7 @@ See our next section for more details about DataSource and Custom Repository.
 
 ### Create new connection
 
-Ts.ED CLI support DataSource creation. Just install the latest Ts.ED CLI version and run the followings command:
+Ts.ED CLI support DataSource creation. Just install the latest Ts.ED CLI version and run the following command:
 
 ```sh
 tsed generate

--- a/packages/di/readme.md
+++ b/packages/di/readme.md
@@ -163,7 +163,7 @@ calendarCtrl.create({name: "My calendar"});
 
 If you can't or don't want to use decorators (e.g. in pure JavaScript), use the **Functional API** introduced in v8+.
 
-For exemple, we can register a provider like this:
+For example, we can register a provider like this:
 
 ```js
 import {injectable, inject} from "@tsed/di";

--- a/packages/orm/mikro-orm/readme.md
+++ b/packages/orm/mikro-orm/readme.md
@@ -213,7 +213,7 @@ export class User {
   lastName!: string;
 
   @Column()
-  @Mininum(0)
+  @Minimum(0)
   @Maximum(100)
   age!: number;
 }

--- a/packages/orm/mikro-orm/readme.md
+++ b/packages/orm/mikro-orm/readme.md
@@ -193,7 +193,7 @@ export class UsersService {
 To begin, we need to define an Entity MikroORM like this and use Ts.ED Decorator to define the JSON Schema.
 
 ```typescript
-import {Property, MaxLength, Required} from "@tsed/schema";
+import {Property, Maximum, MaxLength, Minimum, Required} from "@tsed/schema";
 import {Entity, Property, PrimaryKey, Property as Column} from "@mikro-orm/core";
 
 @Entity()

--- a/packages/orm/objection/readme.md
+++ b/packages/orm/objection/readme.md
@@ -41,7 +41,7 @@ Currently, `@tsed/objection` allows you:
 
 ## Installation
 
-Before using the `@tsed/objection` package, we need to install the [Obection.js](https://www.npmjs.com/package/objection) and [Knex](https://www.npmjs.com/package/knex) modules.
+Before using the `@tsed/objection` package, we need to install the [Objection.js](https://www.npmjs.com/package/objection) and [Knex](https://www.npmjs.com/package/knex) modules.
 
 Install the dependencies:
 

--- a/packages/specs/exceptions/readme.md
+++ b/packages/specs/exceptions/readme.md
@@ -17,7 +17,7 @@
 
 A package of Ts.ED framework. See website: https://tsed.dev/
 
-Ts.ED http exceptions provide classes to throw standard HTTP exceptions. Theses exceptions can be used on Controller, Middleware or injectable Service.
+Ts.ED http exceptions provide classes to throw standard HTTP exceptions. These exceptions can be used on Controller, Middleware or injectable Service.
 Emitted exceptions will be handle by the global error middleware and formatted to an Express response with the right status code and headers.
 
 Other thing. This module can be used with a pure Express application.

--- a/packages/specs/openapi-utils/readme.md
+++ b/packages/specs/openapi-utils/readme.md
@@ -191,7 +191,7 @@ export class Calendar {
 }
 ```
 
-::: warninig
+::: warning
 To update the swagger.json you need to reload the server before.
 :::
 

--- a/packages/specs/swagger/readme.md
+++ b/packages/specs/swagger/readme.md
@@ -191,7 +191,7 @@ export class Calendar {
 }
 ```
 
-::: warninig
+::: warning
 To update the swagger.json you need to reload the server before.
 :::
 

--- a/packages/third-parties/bullmq/README.md
+++ b/packages/third-parties/bullmq/README.md
@@ -251,7 +251,7 @@ class MyService {
     // When passing only a name, the job will be dispatched in a queue named "default"
     await this.dispatcher.dispatch("some-name", {msg: "this message is part of the payload for the job"});
 
-    // You can also specifiy which queue to use
+    // You can also specify which queue to use
     await this.dispatcher.dispatch({queue: "some-queue", name: "some-name"}, {msg: "this message is part of the payload for the job"});
   }
 }
@@ -275,7 +275,7 @@ To change or disable this behavior, set `logLevel` in the configuration.
 export class Server {}
 ```
 
-**Note**: The module logs when job controller is missing as `warn`. This cannot be separetely controlled.
+**Note**: The module logs when job controller is missing as `warn`. This cannot be separately controlled.
 
 ## Contributors
 

--- a/packages/third-parties/socketio-testing/readme.md
+++ b/packages/third-parties/socketio-testing/readme.md
@@ -231,7 +231,7 @@ import {SocketMiddlewareError, SocketErr, Socket} from "@tsed/socketio";
 export class ErrorHandlerSocketMiddleware {
   async use(@SocketErr err: any, @Socket socket: SocketIO.Socket) {
     console.error(err);
-    socket.emit("error", {message: "An error has occured"});
+    socket.emit("error", {message: "An error has occurred"});
   }
 }
 ```

--- a/packages/third-parties/socketio/readme.md
+++ b/packages/third-parties/socketio/readme.md
@@ -275,7 +275,7 @@ import {SocketMiddlewareError, SocketErr, Socket} from "@tsed/socketio";
 export class ErrorHandlerSocketMiddleware {
   async use(@SocketErr err: any, @Socket socket: SocketIO.Socket) {
     console.error(err);
-    socket.emit("error", {message: "An error has occured"});
+    socket.emit("error", {message: "An error has occurred"});
   }
 }
 ```


### PR DESCRIPTION
`docs/tutorials/mikroorm.md` and `packages/orm/mikro-orm/readme.md` document an entity using `@Mininum(0)`, a decorator that does not exist. The real decorator is `@Minimum` (`packages/specs/schema/src/decorators/common/minimum.ts`), and every other doc page spells it that way, so the sample fails to compile as written.

A few other corrections that affect more than spelling:

- `docs/tutorials/oidc.md` describes the route as `/interation/:uid` while the controller it points to declares `/interaction/:uid`.
- `docs/docs/testing.md` refers to `PlatformTest.boostrap()`; the method is `bootstrap()`, as used everywhere else in the page.
- Three custom containers were written as `::: warninig` (swagger and openapi-utils readmes) and `::: warn` (middlewares guide) instead of `::: warning`, so they did not render as callouts.

The rest are plain spelling fixes in prose and code comments across `docs/` and the package readmes (planed, choosen, followings, Serveless, Obection.js, occured, and similar). No code files are touched.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected spelling, grammar, and wording throughout guides, tutorials, package READMEs, and examples.
  - Fixed documented method, decorator, package, command, and error-message names.
  - Corrected Markdown warning directives so callouts render properly.
  - Updated example annotations and imports in MikroORM documentation.
  - Improved clarity and consistency in migration, configuration, testing, and integration documentation.
  - No functional or behavioral changes were made.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->